### PR TITLE
Update composer descriptor to work with S7 and PHP8.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-20.04]
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 ffmpeg: [5.0, 4.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,8 @@
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
-        "symfony/process": "^5.4 || ^6.0",
-        "symfony/cache": "^5.4 || ^6.0"
+        "symfony/process": "^5.4 || ^6.0 || ^7.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Update composer descriptor to work with S7 and PHP8.3

#### Why?

To update API to S7

#### Example Usage

```php
$foo = new Foo();

// Now we can do
$foo->doSomething();

// Remove this section if not needed
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here (Remove this section if not needed).

#### To Do

- [ ] Create tests
