### PR TITLE
Add support for Symfony 8.0 and PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,12 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
-        "symfony/process": "^5.4 || ^6.0 || ^7.0",
-        "symfony/cache": "^5.4 || ^6.0 || ^7.0"
+        "symfony/process": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"


### PR DESCRIPTION
## Summary

This PR adds support for Symfony 8.0 and PHP 8.5 to the library, enabling compatibility with the latest versions of Symfony and PHP.

## Changes

- Updated `symfony/process` dependency to support `^8.0` (alongside existing `^5.4 || ^6.0 || ^7.0`)
- Updated `symfony/cache` dependency to support `^8.0` (alongside existing `^5.4 || ^6.0 || ^7.0`)  
- Added PHP `^8.5` to the list of supported PHP versions

## Motivation

Symfony 8.0 was released and projects are beginning to upgrade. This change ensures the library remains compatible with these upgrades without requiring a major version bump.

## Testing

The changes are purely version constraint updates. No code changes were necessary as the library already works with Symfony 8.0's API.

## Backwards Compatibility

✅ This change is fully backwards compatible. All previously supported versions (Symfony 5.4, 6.0, 7.0 and PHP 8.0-8.4) remain supported.